### PR TITLE
Add CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,26 @@
+name: CompatHelper
+
+on:
+  schedule:
+    - cron: '00 04 * * 4'
+  workflow_dispatch:
+
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Install CompatHelper"
+        shell: julia --color=yes {0}
+        run: |
+          import Pkg
+          name = "CompatHelper"
+          uuid = "aa819f21-2bde-4658-8897-bab36330d9b7"
+          version = "2"
+          Pkg.add(; name, uuid, version)
+      - name: "Run CompatHelper"
+        shell: julia --color=yes {0}
+        run: |
+          import CompatHelper
+          CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
CompatHelper opens a PR when compat entries in the `Project.toml` are outdated.

Also used by, [DataFrames.jl](https://github.com/JuliaData/DataFrames.jl/blob/main/.github/workflows/CompatHelper.yml), [StatsBase.jl](https://github.com/JuliaStats/StatsBase.jl/blob/master/.github/workflows/CompatHelper.yml) and many more packages.