### PR TITLE
Update compat entries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "EffectSizes"
 uuid = "e248de7e-9197-5860-972e-353a2af44d75"
 authors = ["harryscholes <harryscholes@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -9,8 +9,8 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-Distributions = "0.23.2"
-StatsBase = "0.33.0"
+Distributions = "0.23, 0.24, 0.25"
+StatsBase = "0.33"
 julia = "1.0"
 
 [extras]


### PR DESCRIPTION
I've tested the package with Distributions 0.23, 0.24 and 0.25 separately. Also tested with the newest StatsBase, that is, StatsBase 0.33.9.